### PR TITLE
Return an empty string if the emojis are not supported

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ const emojic = module.exports = {};
 // Append the chars to it
 iterateObject(emojis, function (value, name) {
     
-    if (!process.stdout.isTTY || !process.platform === 'darwin')
+    if (process.platform === 'win32')
         return "";
     
     switch (name) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,10 @@ const emojic = module.exports = {};
 
 // Append the chars to it
 iterateObject(emojis, function (value, name) {
+    
+    if (!process.stdout.isTTY || !process.platform === 'darwin')
+        return "";
+    
     switch (name) {
         case "+1":
             name = "thumbs-up";


### PR DESCRIPTION
Emojis are not supported in windows terminals instead you will see weird characters, this PR adds a check if the platform does not support emojis we return an empty string